### PR TITLE
Get question from platform

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,7 +7,7 @@ import {PlatformDetailComponent} from "./view/platform-detail/platform-detail.co
 const routes: Routes = [
   { path: 'platforms', component: PlatformComponent },
   { path: 'addplatform', component: PlatformFormComponent },
-  { path: 'platform/:name', component: PlatformDetailComponent }
+  { path: 'platform/:id', component: PlatformDetailComponent }
 ];
 
 @NgModule({

--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -19,4 +19,8 @@ export class PlatformService {
   public save(platform: Platform) {
     return this.http.post<Platform>(this.platformsUrl, platform);
   }
+
+  public find(id: string): Observable<Platform> {
+    return this.http.get<Platform>(`${this.platformsUrl}/${id}`);
+  }
 }

--- a/src/app/services/question.service.spec.ts
+++ b/src/app/services/question.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { QuestionServiceService } from './question-service.service';
+import { QuestionServiceService } from './question.service';
 
 describe('QuestionServiceService', () => {
   let service: QuestionServiceService;

--- a/src/app/services/question.service.ts
+++ b/src/app/services/question.service.ts
@@ -11,8 +11,8 @@ export class QuestionService {
     this.platformsUrl = 'http://localhost:8081/question';
   }
 
-  getQuestionsForPlatform(platformName: string): Observable<Question[]> {
-    const url = `${this.platformsUrl}`;
+  getQuestionsForPlatform(platformId: string): Observable<Question[]> {
+    const url = `${this.platformsUrl}/platform/${platformId}`;
     return this.http.get<Question[]>(url);
   }
 

--- a/src/app/view/platform-detail/platform-detail.component.html
+++ b/src/app/view/platform-detail/platform-detail.component.html
@@ -1,4 +1,4 @@
-<h2>{{ platformName }} Questions</h2>
+<h2>{{ platform.platformName }} Questions</h2>
 <ul>
   <li *ngFor="let question of questions">
     {{ question.textQuestion }}

--- a/src/app/view/platform-detail/platform-detail.component.ts
+++ b/src/app/view/platform-detail/platform-detail.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import {Question} from "../../model/question/question";
-import {QuestionService} from "../../services/question-service.service";
+import {QuestionService} from "../../services/question.service";
+import {Platform} from "../../model/platform/platform";
+import {PlatformService} from "../../services/platform.service";
 
 @Component({
   selector: 'app-platform-detail',
@@ -9,18 +11,26 @@ import {QuestionService} from "../../services/question-service.service";
   styleUrls: ['./platform-detail.component.css']
 })
 export class PlatformDetailComponent implements OnInit {
-  platformName: string;
+  platformId: string;
+  platform: Platform;
   questions: Question[];
 
   constructor(private route: ActivatedRoute,
-              private questionService: QuestionService) { }
+              private questionService: QuestionService,
+              private platformService: PlatformService) { }
 
   ngOnInit(): void {
-    this.platformName = this.route.snapshot.paramMap.get('name');
+    this.platformId = this.route.snapshot.paramMap.get('id');
+    this.loadPlatform();
     this.loadQuestions();
   }
+  private loadPlatform(): void {
+    this.platformService.find(this.platformId)
+      .subscribe(platform => this.platform = platform);
+  }
+
   private loadQuestions(): void {
-    this.questionService.getQuestionsForPlatform(this.platformName)
+    this.questionService.getQuestionsForPlatform(this.platformId)
       .subscribe(questions => this.questions = questions);
   }
 }

--- a/src/app/view/platform/platform.component.html
+++ b/src/app/view/platform/platform.component.html
@@ -9,7 +9,7 @@
       <tbody>
       <tr *ngFor="let platform of platforms">
         <td>
-          <a [routerLink]="['/platform', platform.platformName]">{{ platform.platformName }}</a>
+          <a [routerLink]="['/platform', platform.id]">{{ platform.platformName }}</a>
         </td>
       </tr>
       </tbody>


### PR DESCRIPTION
It has been fixed that the questions are not loaded when the platform is selected.

This has been achieved by using the id for navigation and loading in the platformName using that id.